### PR TITLE
Better checking for pecl-json-c

### DIFF
--- a/src/Minime/Annotations/Parser.php
+++ b/src/Minime/Annotations/Parser.php
@@ -217,7 +217,7 @@ class Parser implements ParserInterface
     protected static function jsonDecode($value)
     {
         if (static::useJsoncStrategy()) { // routine for pecl-json-c
-            $json_decoded = json_decode($value, false, 512,  JSON_PARSER_NOTSTRICT);
+            $json_decoded = json_decode($value, false, 512, JSON_PARSER_NOTSTRICT);
         } else { // legacy routine for superseded ext-json
             $json_decoded = json_decode($value);
         }
@@ -227,7 +227,7 @@ class Parser implements ParserInterface
 
     protected static function useJsoncStrategy()
     {
-        return defined('JSON_C_VERSION');
+        return defined('JSON_PARSER_NOTSTRICT');
     }
 
     /**


### PR DESCRIPTION
Parser should rely on `JSON_PARSER_NOTSTRICT` presence instead of `JSON_C_VERSION`
