### PR TITLE
Implements Reusable Parser #26

### DIFF
--- a/src/Minime/Annotations/Facade.php
+++ b/src/Minime/Annotations/Facade.php
@@ -58,7 +58,7 @@ class Facade
     protected static function getAnnotations(Reflector $Reflection)
     {
         $Rules = new ParserRules;
-        $annotations = (new Parser($Reflection->getDocComment(), $Rules))->parse();
+        $annotations = (new Parser($Rules))->parse($Reflection->getDocComment());
 
         return new AnnotationsBag($annotations, $Rules);
     }

--- a/src/Minime/Annotations/Interfaces/ParserInterface.php
+++ b/src/Minime/Annotations/Interfaces/ParserInterface.php
@@ -17,5 +17,5 @@ interface ParserInterface
      * @return array
      *
      */
-    public function parse();
+    public function parse($str);
 }

--- a/src/Minime/Annotations/Parser.php
+++ b/src/Minime/Annotations/Parser.php
@@ -16,13 +16,6 @@ use Minime\Annotations\Interfaces\ParserRulesInterface;
 class Parser implements ParserInterface
 {
     /**
-     * The Doc block to parse
-     *
-     * @var string
-     */
-    private $raw_doc_block;
-
-    /**
      * The ParserRules object
      *
      * @var ParserRulesInterface
@@ -53,11 +46,10 @@ class Parser implements ParserInterface
     /**
      * Parser constructor
      *
-     * @param string $raw_doc_block the doc block to parse
+     * @param ParserRulesInterface $rules the ParserRules object
      */
-    public function __construct($raw_doc_block, ParserRulesInterface $rules)
+    public function __construct(ParserRulesInterface $rules)
     {
-        $this->raw_doc_block = $raw_doc_block;
         $this->types_pattern = '/^('.implode('|', $this->types).')(\s)*(\S)+/';
         $this->rules = $rules;
         $identifier = $rules->getAnnotationIdentifier();
@@ -69,11 +61,13 @@ class Parser implements ParserInterface
     /**
      * Parse a given docblock
      *
+     * @param string $str the string to be parsed
+     *
      * @return array
      */
-    public function parse()
+    public function parse($str)
     {
-        $annotations = $this->parseAnnotations($this->raw_doc_block);
+        $annotations = $this->parseAnnotations($str);
         foreach ($annotations as &$value) {
             if (1 == count($value)) {
                 $value = $value[0];
@@ -87,7 +81,8 @@ class Parser implements ParserInterface
     /**
      * Creates raw [annotation => value, [...]] tree
      *
-     * @param  string $str
+     * @param string $str
+     *
      * @return array
      */
     protected function parseAnnotations($str)
@@ -104,10 +99,12 @@ class Parser implements ParserInterface
     /**
      * Parse a single annotation value
      *
-     * @param  string          $value
-     * @param  string          $type  the type to parse the value against
-     * @throws ParserException If the type is not recognized
+     * @param string $value
+     * @param string $type  the type to parse the value against
+     *
      * @return mixed
+     *
+     * @throws ParserException If the type is not recognized
      */
     public function parseValue($value)
     {

--- a/test/suite/Minime/Annotations/ParserTest.php
+++ b/test/suite/Minime/Annotations/ParserTest.php
@@ -16,18 +16,12 @@ class ParserTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->Fixture = new AnnotationsFixture;
+		$this->Parser = new Parser(new ParserRules);
     }
 
-    public function tearDown()
+    private function getDocBlock($fixture)
     {
-        $this->Fixture = null;
-    }
-
-    private function getParser($fixture)
-    {
-        $reflection = new ReflectionProperty($this->Fixture, $fixture);
-
-        return new Parser($reflection->getDocComment(), new ParserRules);
+        return (new ReflectionProperty($this->Fixture, $fixture))->getDocComment();
     }
 
     /**
@@ -44,7 +38,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseEmptyFixture()
     {
-        $annotations = $this->getParser('empty_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('empty_fixture'));
         $this->assertSame([], $annotations);
     }
 
@@ -53,7 +47,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseNullFixture()
     {
-        $annotations = $this->getParser('null_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('null_fixture'));
         $this->assertSame([null, null, ''], $annotations['value']);
     }
 
@@ -62,7 +56,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseBooleanFixture()
     {
-        $annotations = $this->getParser('boolean_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('boolean_fixture'));
         $this->assertSame([true, false, true, false, "true", "false"], $annotations['value']);
     }
 
@@ -71,7 +65,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseImplicitBooleanFixture()
     {
-        $annotations = $this->getParser('implicit_boolean_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('implicit_boolean_fixture'));
         $this->assertSame(true, $annotations['alpha']);
         $this->assertSame(true, $annotations['beta']);
         $this->assertSame(true, $annotations['gamma']);
@@ -83,7 +77,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseStringFixture()
     {
-        $annotations = $this->getParser('string_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('string_fixture'));
         $this->assertSame(['abc', 'abc', 'abc ', '123'], $annotations['value']);
     }
 
@@ -92,7 +86,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseIdentifierFixture()
     {
-        $annotations = $this->getParser('identifier_parsing_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('identifier_parsing_fixture'));
         $this->assertSame(['bar' => 'test@example.com', 'toto' => true, 'tata' => true, 'number' => 2.1], $annotations);
     }
 
@@ -101,7 +95,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseIntegerFixture()
     {
-        $annotations = $this->getParser('integer_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('integer_fixture'));
         $this->assertSame([123, 23, -23], $annotations['value']);
     }
 
@@ -110,7 +104,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseFloatFixture()
     {
-        $annotations = $this->getParser('float_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('float_fixture'));
         $this->assertSame([.45, 0.45, 45., -4.5], $annotations['value']);
     }
 
@@ -119,7 +113,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseJsonFixture()
     {
-        $annotations = $this->getParser('json_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('json_fixture'));
         $this->assertEquals(
             [
                 ["x", "y"],
@@ -135,7 +129,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseEvalFixture()
     {
-        $annotations = $this->getParser('eval_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('eval_fixture'));
         $this->assertEquals(
             [
                 86400000,
@@ -151,7 +145,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseSingleValuesFixture()
     {
-        $annotations = $this->getParser('single_values_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('single_values_fixture'));
         $this->assertEquals('foo', $annotations['param_a']);
         $this->assertEquals('bar', $annotations['param_b']);
     }
@@ -161,7 +155,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseMultipleValuesFixture()
     {
-        $annotations = $this->getParser('multiple_values_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('multiple_values_fixture'));
         $this->assertEquals(['x', 'y', 'z'], $annotations['value']);
     }
 
@@ -170,7 +164,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseParseSameLineFixture()
     {
-        $annotations = $this->getParser('same_line_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('same_line_fixture'));
         $this->assertSame(true, $annotations['get']);
         $this->assertSame(true, $annotations['post']);
         $this->assertSame(true, $annotations['ajax']);
@@ -185,7 +179,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function namespacedAnnotations()
     {
-        $annotations = $this->getParser('namespaced_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('namespaced_fixture'));
 
         $this->assertSame('cheers!', $annotations['path.to.the.treasure']);
         $this->assertSame('the cake is a lie', $annotations['path.to.the.cake']);
@@ -197,7 +191,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseStrongTypedFixture()
     {
-        $annotations = $this->getParser('strong_typed_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('strong_typed_fixture'));
         $declarations = $annotations['value'];
         $this->assertNotEmpty($declarations);
         $this->assertSame(
@@ -225,7 +219,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseReservedWordsAsValue()
     {
-        $annotations = $this->getParser('reserved_words_as_value_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('reserved_words_as_value_fixture'));
         $expected = ['string','integer','float','json','eval'];
         $this->assertSame($expected, $annotations['value']);
         $this->assertSame($expected, $annotations['value_with_trailing_space']);
@@ -236,7 +230,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function tolerateUnrecognizedTypes()
     {
-        $annotations = $this->getParser('non_recognized_type_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('non_recognized_type_fixture'));
         $this->assertEquals("footype Tolerate me. DockBlocks can't be evaluated rigidly.", $annotations['value']);
     }
 
@@ -245,13 +239,13 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function parseInlineDocblocks()
     {
-        $annotations = $this->getParser('inline_docblock_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('inline_docblock_fixture'));
         $this->assertSame('foo', $annotations['value']);
 
-        $annotations = $this->getParser('inline_docblock_implicit_boolean_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('inline_docblock_implicit_boolean_fixture'));
         $this->assertSame(true, $annotations['alpha']);
 
-        $annotations = $this->getParser('inline_docblock_multiple_implicit_boolean_fixture')->parse();
+        $annotations = $this->Parser->parse($this->getDocBlock('inline_docblock_multiple_implicit_boolean_fixture'));
         $this->assertSame(true, $annotations['alpha']);
         $this->assertSame(true, $annotations['beta']);
         $this->assertSame(true, $annotations['gama']);
@@ -263,7 +257,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function badJSONValue()
     {
-        $this->getParser('bad_json_fixture')->parse();
+        $this->Parser->parse($this->getDocBlock('bad_json_fixture'));
     }
 
     /**
@@ -272,7 +266,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function badEvalValue()
     {
-        $this->getParser('bad_eval_fixture')->parse();
+        $this->Parser->parse($this->getDocBlock('bad_eval_fixture'));
     }
 
     /**
@@ -281,7 +275,7 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function badIntegerValue()
     {
-        $this->getParser('bad_integer_fixture')->parse();
+        $this->Parser->parse($this->getDocBlock('bad_integer_fixture'));
     }
 
     /**
@@ -290,6 +284,6 @@ class ParserTest extends \PHPUnit_Framework_TestCase
      */
     public function badFloatValue()
     {
-        $this->getParser('bad_float_fixture')->parse();
+        $this->Parser->parse($this->getDocBlock('bad_float_fixture'));
     }
 }


### PR DESCRIPTION
Implements Reusable Parser #26 
- Rewrote `ParserInterface` Interface to enable modifying `Parser::parse` method signature;
- Rewrote `Parser` class to enable reusable parser by moving the string to be parse from the class constructor to the `Parser::parse` method.
- Rewrote `Facade::getAnnotations` method and the `ParserTest` class to take into account the changes made;
