### PR TITLE
Prefixing PHP-Doc @return tags with a backslash

### DIFF
--- a/src/Minime/Annotations/AnnotationsBag.php
+++ b/src/Minime/Annotations/AnnotationsBag.php
@@ -136,7 +136,7 @@ class AnnotationsBag implements \IteratorAggregate, \Countable, \ArrayAccess, \J
      * Filters annotations based on a regexp
      * @param  string                            $pattern Valid regexp
      * @throws \InvalidArgumentException         If non valid regexp is passed
-     * @return Minime\Annotations\AnnotationsBag Annotations collection with filtered results
+     * @return \Minime\Annotations\AnnotationsBag Annotations collection with filtered results
      */
     public function grep($pattern)
     {
@@ -156,7 +156,7 @@ class AnnotationsBag implements \IteratorAggregate, \Countable, \ArrayAccess, \J
      *
      * @deprecated
      * @param string $pattern namespace
-     * @return Minime\Annotations\AnnotationsBag
+     * @return \Minime\Annotations\AnnotationsBag
      */
     public function grepNamespace($pattern)
     {
@@ -167,7 +167,7 @@ class AnnotationsBag implements \IteratorAggregate, \Countable, \ArrayAccess, \J
      * Isolates a given namespace of annotations.
      * @param string $pattern namespace
      *
-     * @return Minime\Annotations\AnnotationsBag
+     * @return \Minime\Annotations\AnnotationsBag
      */
     public function useNamespace($pattern)
     {
@@ -194,7 +194,7 @@ class AnnotationsBag implements \IteratorAggregate, \Countable, \ArrayAccess, \J
      * Performs union operations against a given AnnotationsBag
      * 
      * @param AnnotationsBag $bag The annotation bag to be united
-     * @return Minime\Annotations\AnnotationsBag Annotations collection with union results
+     * @return \Minime\Annotations\AnnotationsBag Annotations collection with union results
      */
     public function union(AnnotationsBag $bag)
     {

--- a/src/Minime/Annotations/Facade.php
+++ b/src/Minime/Annotations/Facade.php
@@ -21,7 +21,7 @@ class Facade
      * Retrieve all annotations from a given class
      *
      * @param  string                            $class Full qualified class name
-     * @return Minime\Annotations\AnnotationsBag Annotations collection
+     * @return \Minime\Annotations\AnnotationsBag Annotations collection
      * @throws \\ReflectionException             If class is not found
      */
     public static function getClassAnnotations($class)
@@ -34,7 +34,7 @@ class Facade
      *
      * @param  string                            $class    Full qualified class name
      * @param  string                            $property Property name
-     * @return Minime\Annotations\AnnotationsBag Annotations collection
+     * @return \Minime\Annotations\AnnotationsBag Annotations collection
      * @throws \\ReflectionException             If property is undefined
      */
     public static function getPropertyAnnotations($class, $property)
@@ -47,7 +47,7 @@ class Facade
      *
      * @param  string                            $class    Full qualified class name
      * @param  string                            $method Method name
-     * @return Minime\Annotations\AnnotationsBag Annotations collection
+     * @return \Minime\Annotations\AnnotationsBag Annotations collection
      * @throws \\ReflectionException             If method is undefined
      */
     public static function getMethodAnnotations($class, $method)

--- a/src/Minime/Annotations/Traits/Reader.php
+++ b/src/Minime/Annotations/Traits/Reader.php
@@ -16,7 +16,7 @@ trait Reader
     /**
      * Retrieve all annotations from current class
      *
-     * @return Minime\Annotations\AnnotationsBag Annotations collection
+     * @return \Minime\Annotations\AnnotationsBag Annotations collection
      */
     public function getClassAnnotations()
     {
@@ -27,7 +27,7 @@ trait Reader
      * Retrieve all annotations from a given property of current class
      *
      * @param  string                            $property Property name
-     * @return Minime\Annotations\AnnotationsBag Annotations collection
+     * @return \Minime\Annotations\AnnotationsBag Annotations collection
      */
     public function getPropertyAnnotations($property)
     {
@@ -38,7 +38,7 @@ trait Reader
      * Retrieve all annotations from a given method of current class
      *
      * @param  string                            $method Method name
-     * @return Minime\Annotations\AnnotationsBag Annotations collection
+     * @return \Minime\Annotations\AnnotationsBag Annotations collection
      */
     public function getMethodAnnotations($method)
     {


### PR DESCRIPTION
My IDE, PHPStorm, was unable to resolve the internal "Minime" namespace without the backslash.
All tests are passing
