### PR TITLE
Constant annotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     "require": {
         "php": ">=5.4.0",
         "ext-json":"*",
-        "regex-guard/regex-guard": "~1.0"
+        "regex-guard/regex-guard": "~1.0",
+        "nikic/php-parser" : "~1.0"
     },
     "require-dev": {
         "mockery/mockery": "dev-master"

--- a/src/Reader.php
+++ b/src/Reader.php
@@ -2,10 +2,11 @@
 
 namespace Minime\Annotations;
 
+use Minime\Annotations\Cache\ArrayCache;
+use Minime\Annotations\Interfaces\CacheInterface;
 use Minime\Annotations\Interfaces\ParserInterface;
 use Minime\Annotations\Interfaces\ReaderInterface;
-use Minime\Annotations\Interfaces\CacheInterface;
-use Minime\Annotations\Cache\ArrayCache;
+use Minime\Annotations\Reflector\ReflectionConst;
 
 /**
  * This class is the primary entry point to read annotations
@@ -113,6 +114,16 @@ class Reader implements ReaderInterface
     public function getMethodAnnotations($class, $method)
     {
         return $this->getAnnotations(new \ReflectionMethod($class, $method));
+    }
+
+    /**
+     * @param string|object                                     $class fully qualified name or instance of the class
+     * @param string                                            $const name of the constant
+     * @return \Minime\Annotations\Interfaces\AnnotationsBagInterface Annotations collection
+     */
+    public function getConstantAnnotations($class, $const)
+    {
+        return $this->getAnnotations(new ReflectionConst($class, $const));
     }
 
     /**

--- a/src/Reflector/ReflectionConst.php
+++ b/src/Reflector/ReflectionConst.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Minime\Annotations\Reflector;
+
+use PhpParser\Error;
+use PhpParser\Lexer;
+use PhpParser\Node\Stmt\Class_;
+use PhpParser\Node\Stmt\ClassConst;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Parser as PHPParser;
+
+/**
+ * We need this class in the annotation reader because there is no builtin constant reflector
+ * We only implemented getDocComment because that's the only feature we need
+ * @see \Minime\Annotations\Reader::getConstantAnnotations()
+ */
+class ReflectionConst implements \Reflector
+{
+
+    protected $classConstNode = null;
+    protected $constNode = null;
+
+    protected $docComment = null;
+
+    /**
+     * @param string|object $class        fully qualified name or instance of the class
+     * @param string $constName           name of the constant
+     * @throws \ReflectionException
+     */
+    public function __construct($class, $constName)
+    {
+
+        $classReflection = new \ReflectionClass($class);
+        $className = $classReflection->getName();
+        $fileName = $classReflection->getFileName();
+
+        $parser = new PHPParser(new Lexer());
+        try {
+            $stmts = $parser->parse(file_get_contents($fileName));
+        } catch (Error $e) {
+            throw new \ReflectionException("Cannot parse the class ${fileName}", 0, $e);
+        }
+
+        // Class can be in a namespace or at the root of the statement
+        $classNode = $this->findClassNode($stmts);
+        if (!$classNode) {
+            throw new \ReflectionException("Class ${className} not found in file ${fileName}");
+        }
+
+
+        // Find the constant we are looking for
+        foreach ($classNode->stmts as $classSubNode) {
+            if ($classSubNode instanceof ClassConst) {
+                foreach ($classSubNode->consts as $constNode) {
+                    if ($constNode->name == $constName) {
+                        $this->classConstNode = $classSubNode;
+                        $this->constNode = $constNode;
+                        break 2;
+                    }
+                }
+            }
+        }
+
+        if (!$this->constNode) {
+            throw new \ReflectionException("Class constant ${constName} does not exist in class ${className}");
+        }
+
+    }
+
+    /**
+     * @param $stmts
+     * @return Class_
+     */
+    private function findClassNode($stmts)
+    {
+        foreach ($stmts as $node) {
+            if ($node instanceof Namespace_) {
+                return $this->findClassNode($node->stmts);
+            } else {
+                if ($node instanceof Class_) {
+                    return $node;
+                }
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @return string
+     */
+    public function getDocComment()
+    {
+
+        if (null == $this->docComment) {
+            /* more than one means we have this case :
+             *  const
+             *     /**
+             *      * @annotation
+             *      * /
+             *      FOO = 'foo',
+             *      /**
+             *      * @annotation
+             *      * /
+             *      BAR = 'bar'
+             * ;
+             *
+             * Else we have this case
+             *
+             * /**
+             *  * @annotation
+             *  * /
+             *  const Foo = 'foo';
+             *
+             */
+            if (count($this->classConstNode->consts) > 1) {
+                $comments = $this->constNode->getAttribute('comments', []);
+            } else {
+                $comments = $this->classConstNode->getAttribute('comments', []);
+            }
+
+            if (count($comments) > 0) {
+                // we can have many doc comment for one statement
+                // We only take the closest one
+                $docComment = end($comments);
+
+                if (substr($docComment, 0, 3) == '/**') {
+                    $this->docComment = $docComment;
+                } else {
+                    $this->docComment = "";
+                }
+
+            } else {
+                $this->docComment = "";
+            }
+
+        }
+
+        return $this->docComment;
+
+
+    }
+
+    /**
+     * No need to implement it, we only need the getDocComment
+     */
+    public static function export()
+    {
+
+    }
+
+    /**
+     * No need to implement it, we only need the getDocComment
+     */
+    public function __toString()
+    {
+        // TODO: Implement __toString() method.
+    }
+}

--- a/test/fixtures/AnnotationsFixture.php
+++ b/test/fixtures/AnnotationsFixture.php
@@ -246,4 +246,34 @@ class AnnotationsFixture
      */
     private function method_fixture() {}
 
+    /**
+     * Related to issue #56
+     * @fix 56
+     * @foo
+     */
+    const CONSTANT_FIXTURE = "someValue";
+
+    /**
+     * Related to issue #56
+     * @fix 56
+     * @foo
+     */
+    const
+        /**
+         * @value foo
+         */
+        CONSTANT_MANY1 = "foo",
+        /**
+         * @value bar
+         * @type constant
+         */
+        CONSTANT_MANY2 = "bar";
+
+
+    const CONSTANT_EMPTY = "empty";
+
+    const
+        CONSTANT_EMPTY_MANY1 = "foo",
+        CONSTANT_EMPTY_MANY2 = "bar";
+
 }

--- a/test/fixtures/AnnotationsFixture.php
+++ b/test/fixtures/AnnotationsFixture.php
@@ -294,7 +294,7 @@ class AnnotationsFixture
         CONSTANT_MANY_WITH_COMMENT_BEFORE_FIRST = "someValue",
         CONSTANT_MANY_WITH_COMMENT_BEFORE_NEXT  = "someValue";
 
-    // No doc comment but simple comment is here
+    // @wrongSyntax
     const CONSTANT_SIMPLE_COMMENT_ONLY = "someValue";
 
 

--- a/test/fixtures/AnnotationsFixture.php
+++ b/test/fixtures/AnnotationsFixture.php
@@ -247,6 +247,9 @@ class AnnotationsFixture
     private function method_fixture() {}
 
     /**
+     * @notRead
+     */
+    /**
      * Related to issue #56
      * @fix 56
      * @foo
@@ -275,5 +278,24 @@ class AnnotationsFixture
     const
         CONSTANT_EMPTY_MANY1 = "foo",
         CONSTANT_EMPTY_MANY2 = "bar";
+
+    /**
+     * Case with comment between doc comment and const
+     * @withComment true
+     */
+    // Some comment
+    const CONSTANT_WITH_COMMENT_BEFORE_DOC = "someValue";
+
+    /**
+     * Case with many const and one doc comment before all
+     * @hasCommentBefore true
+     */
+    const
+        CONSTANT_MANY_WITH_COMMENT_BEFORE_FIRST = "someValue",
+        CONSTANT_MANY_WITH_COMMENT_BEFORE_NEXT  = "someValue";
+
+    // No doc comment but simple comment is here
+    const CONSTANT_SIMPLE_COMMENT_ONLY = "someValue";
+
 
 }

--- a/test/suite/ReaderTest.php
+++ b/test/suite/ReaderTest.php
@@ -81,7 +81,7 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_MANY1");
         $this->assertCount(1, $annotations);
         $this->assertSame($annotations->get("value"), "foo");
-
+        // second constant has comment
         $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_MANY2");
         $this->assertCount(2, $annotations);
         $this->assertSame($annotations->get("value"), "bar");
@@ -95,9 +95,34 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         // Many constant under the same const declaration with no anntation
         $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_EMPTY_MANY1");
         $this->assertCount(0, $annotations);
-
+        // second constant
         $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_EMPTY_MANY2");
         $this->assertCount(0, $annotations);
+
+
+        // Test case with comment between doc and constant
+        $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_WITH_COMMENT_BEFORE_DOC");
+        $this->assertCount(1, $annotations);
+        $this->assertSame(true, $annotations->get("withComment"));
+
+
+        // Test case with one comment before many constants
+        $annotations = $this
+            ->getReader()
+            ->getConstantAnnotations($this->fixture, "CONSTANT_MANY_WITH_COMMENT_BEFORE_FIRST");
+        $this->assertCount(1, $annotations);
+        $this->assertSame(true, $annotations->get("hasCommentBefore"));
+        // Next constant has nothing
+        $annotations = $this
+            ->getReader()
+            ->getConstantAnnotations($this->fixture, "CONSTANT_MANY_WITH_COMMENT_BEFORE_NEXT");
+        $this->assertCount(0, $annotations);
+
+
+        // Test case with no doc comment but with simple comment
+        $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_SIMPLE_COMMENT_ONLY");
+        $this->assertCount(0, $annotations);
+
 
     }
 

--- a/test/suite/ReaderTest.php
+++ b/test/suite/ReaderTest.php
@@ -67,6 +67,40 @@ class ReaderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($annotations->get('post'));
     }
 
+    public function testReadConstantAnnotations()
+    {
+
+        // Single constant with annotation
+        $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_FIXTURE");
+        $this->assertCount(2, $annotations);
+        $this->assertSame($annotations->get("fix"), 56);
+        $this->assertTrue($annotations->has("foo"));
+
+
+        // Many constant under the same const declaration with annotation
+        $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_MANY1");
+        $this->assertCount(1, $annotations);
+        $this->assertSame($annotations->get("value"), "foo");
+
+        $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_MANY2");
+        $this->assertCount(2, $annotations);
+        $this->assertSame($annotations->get("value"), "bar");
+        $this->assertSame($annotations->get("type"), "constant");
+
+
+        // single const with no anntation
+        $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_EMPTY");
+        $this->assertCount(0, $annotations);
+
+        // Many constant under the same const declaration with no anntation
+        $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_EMPTY_MANY1");
+        $this->assertCount(0, $annotations);
+
+        $annotations = $this->getReader()->getConstantAnnotations($this->fixture, "CONSTANT_EMPTY_MANY2");
+        $this->assertCount(0, $annotations);
+
+    }
+
     public function testCreateFromDefaults()
     {
         $this->assertInstanceOf('Minime\Annotations\Reader', Reader::createFromDefaults());


### PR DESCRIPTION
View #56 

I implemented constant annotation with https://github.com/nikic/PHP-Parser

- Test are written: https://github.com/marcioAlmada/annotations/compare/master...gsouf:master#diff-0bead099dbf66baa309e8061718a7defR70
- I added a class ReflectionConst that imeplements \Reflector in order to keep make it work with getAnnotations: https://github.com/gsouf/annotations/blob/918194f3d11bba3dcdfd95660bfd9c8441d01d79/src/Reader.php#L135