### PR TITLE
bump nikic/php-parser requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": ">=5.4.0",
         "ext-json":"*",
         "regex-guard/regex-guard": "~1.0",
-        "nikic/php-parser" : ">=2.0 <4.0.0"
+        "nikic/php-parser" : ">=2.0 <5.0.0"
     },
     "require-dev": {
         "mockery/mockery": "^0.9",


### PR DESCRIPTION
Bumping nikic/php-parser requirement to the latest version. right now it breaks on the packages that use php-parser >4.0. i ran the test and it didn't break the code it is currently using on (`Reader::getConstantAnnotations`).

Thanks! :D