### PR TITLE
feat: drop hhvm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 matrix:
   allow_failures:


### PR DESCRIPTION
HHVM is no longer php-compatible as of 2017 and tests fail hard in travis because of composer problems.

https://www.infoworld.com/article/3226489/forget-php-facebooks-hhvm-engine-switches-to-hack-instead.html